### PR TITLE
refactor(server): 移除 JudgeTestRun 接口中 Stdin 字段的 required 验证

### DIFF
--- a/server/handler/judge.go
+++ b/server/handler/judge.go
@@ -68,7 +68,7 @@ func JudgeSubmit(c *gin.Context) {
 type ReqJudgeTestRun struct {
 	LanguageId uint64 `json:"language_id" binding:"required"`
 	SourceCode string `json:"source_code" binding:"required"`
-	Stdin      string `json:"stdin" binding:"required"`
+	Stdin      string `json:"stdin"`
 }
 
 func JudgeTestRun(c *gin.Context) {


### PR DESCRIPTION
- 修改了 ReqJudgeTestRun 结构体中 Stdin 字段的 binding 标签，从 "required" 改为无验证
- 这个改动是为了在测试运行时可以无输入进行测试