### PR TITLE
Update model strings

### DIFF
--- a/internal/entity/blog.go
+++ b/internal/entity/blog.go
@@ -16,13 +16,13 @@ const (
 func (s BlogStatus) String() string {
 	switch s {
 	case BLogStatusBanned:
-		return "被屏蔽"
+		return "屏蔽"
 	case BlogStatusPublic:
 		return "公开"
 	case BlogStatusDraft:
 		return "草稿"
 	case BLogStatusReview:
-		return "待审核"
+		return "审核"
 	case BlogStatusNotice:
 		return "公告"
 	default:

--- a/internal/entity/comment.go
+++ b/internal/entity/comment.go
@@ -13,7 +13,7 @@ const (
 func (s CommentStatus) String() string {
 	switch s {
 	case CommentStatusBanned:
-		return "被屏蔽"
+		return "屏蔽"
 	case CommentStatusPublic:
 		return "公开"
 	default:

--- a/internal/entity/problem.go
+++ b/internal/entity/problem.go
@@ -68,7 +68,7 @@ type Problem struct {
 	Id           uint64        `gorm:"primaryKey;autoIncrement;comment:题目ID" json:"id,omitempty"`
 	Title        string        `gorm:"type:text;not null;comment:标题" json:"title,omitempty"`
 	Source       string        `gorm:"type:text;not null;comment:题目来源" json:"source,omitempty"`
-	Difficulty   Difficulty    `gorm:"not null;default:0;comment:难度" json:"difficulty,omitempty"`
+	Difficulty   Difficulty    `gorm:"not null;default:0;comment:难度" json:"difficulty"`
 	TimeLimit    float64       `gorm:"not null;default:1;comment:时间限制（s）" json:"time_limit,omitempty"`
 	MemoryLimit  uint64        `gorm:"not null;default:131072;comment:内存限制（kb）" json:"memory_limit,omitempty"`
 	Description  string        `gorm:"type:longtext;not null;comment:题面" json:"description,omitempty"`

--- a/internal/entity/problem.go
+++ b/internal/entity/problem.go
@@ -4,37 +4,37 @@ import (
 	"time"
 )
 
-// 难度：0 暂无评定，1 E级（入门），2 D级（简单），3 C级（中等），4 B级（较难），5 A级（困难），6 S级（超级困难）
+// 难度：0 未知，1 入门，2 简单，3 中等，4 较难，5 困难，6 超难
 type Difficulty uint8
 
 const (
-	DifficultyUnknown Difficulty = 0
-	DifficultyE       Difficulty = 1
-	DifficultyD       Difficulty = 2
-	DifficultyC       Difficulty = 3
-	DifficultyB       Difficulty = 4
-	DifficultyA       Difficulty = 5
-	DifficultyS       Difficulty = 6
+	DifficultyU Difficulty = 0
+	DifficultyE Difficulty = 1
+	DifficultyD Difficulty = 2
+	DifficultyC Difficulty = 3
+	DifficultyB Difficulty = 4
+	DifficultyA Difficulty = 5
+	DifficultyS Difficulty = 6
 )
 
 func (d Difficulty) String() string {
 	switch d {
-	case DifficultyUnknown:
-		return "暂无评定"
+	case DifficultyU:
+		return "[?]未知"
 	case DifficultyE:
-		return "E级（入门）"
+		return "[E]入门"
 	case DifficultyD:
-		return "D级（简单）"
+		return "[D]简单"
 	case DifficultyC:
-		return "C级（中等）"
+		return "[C]中等"
 	case DifficultyB:
-		return "B级（较难）"
+		return "[B]较难"
 	case DifficultyA:
-		return "A级（困难）"
+		return "[A]困难"
 	case DifficultyS:
-		return "S级（超级困难）"
+		return "[S]超难"
 	default:
-		return "暂无评定"
+		return "[?]未知"
 	}
 }
 
@@ -55,11 +55,11 @@ func (s ProblemStatus) String() string {
 	case ProblemStatusPublic:
 		return "公开"
 	case ProblemStatusEditing:
-		return "出题中"
+		return "出题"
 	case ProblemStatusDebugging:
-		return "调试中"
+		return "调试"
 	default:
-		return "未知状态"
+		return "未知"
 	}
 }
 
@@ -77,7 +77,7 @@ type Problem struct {
 	SampleInput  string        `gorm:"type:longtext;not null;comment:输入样例" json:"sample_input,omitempty"`
 	SampleOutput string        `gorm:"type:longtext;not null;comment:输出样例" json:"sample_output,omitempty"`
 	Hint         string        `gorm:"type:longtext;not null;comment:提示" json:"hint,omitempty"`
-	Status       ProblemStatus `gorm:"not null;default:1;comment:状态" json:"status"`
+	Status       ProblemStatus `gorm:"not null;default:0;comment:状态" json:"status"`
 	ProblemTag   []*Tag        `gorm:"many2many:tbl_problem_tag;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;association_jointable_foreignkey:tag_id;jointable_foreignkey:problem_id" json:"problem_tag,omitempty"`
 	CreateTime   time.Time     `gorm:"not null;default:CURRENT_TIMESTAMP;comment:创建时间" json:"create_time,omitempty"`
 	UpdateTime   time.Time     `gorm:"not null;default:CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;comment:更新时间" json:"update_time,omitempty"`

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -20,15 +20,15 @@ const (
 func (r Role) String() string {
 	switch r {
 	case RoleBanned:
-		return "被封禁用户"
+		return "封禁"
 	case RoleUser:
-		return "普通用户"
+		return "用户"
 	case RoleAdmin:
-		return "管理员"
+		return "管理"
 	case RoleRoot:
-		return "超级管理员"
+		return "超管"
 	default:
-		return "未知角色"
+		return "未知"
 	}
 }
 


### PR DESCRIPTION
This pull request includes various changes to improve consistency and clarity in the string representations of different statuses and roles across multiple files. The most important changes include updates to the `BlogStatus`, `CommentStatus`, `Difficulty`, `ProblemStatus`, and `Role` string representations.

Changes to status and role string representations:

* [`internal/entity/blog.go`](diffhunk://#diff-bbed23c49e5176262ea7aae2688864c6f92a85f218025387755c6423ef3df463L19-R25): Simplified the string representations of `BlogStatus` from phrases like "被屏蔽" to "屏蔽" and "待审核" to "审核".
* [`internal/entity/comment.go`](diffhunk://#diff-8083308de2a00b6a560c238090c03c0c0588c71e15595de24a736cb78b08b022L16-R16): Simplified the string representation of `CommentStatus` from "被屏蔽" to "屏蔽".
* [`internal/entity/problem.go`](diffhunk://#diff-4ce5e0d71112ab310c769be79fa4ac40e64e2c930e84c17334affed1fb0d979dL22-R37): Updated the string representations of `Difficulty` levels to use a more concise format, e.g., "E级（入门）" to "[E]入门".
* [`internal/entity/problem.go`](diffhunk://#diff-4ce5e0d71112ab310c769be79fa4ac40e64e2c930e84c17334affed1fb0d979dL58-R62): Simplified the string representations of `ProblemStatus` from "出题中" to "出题" and "调试中" to "调试".
* [`internal/entity/user.go`](diffhunk://#diff-28c6510b5d03dfb7ad9c9640512502ed8ca0294901bc303b392ce23cebc6a357L23-R31): Simplified the string representations of `Role` from phrases like "被封禁用户" to "封禁" and "超级管理员" to "超管".

Other changes:

* [`internal/entity/problem.go`](diffhunk://#diff-4ce5e0d71112ab310c769be79fa4ac40e64e2c930e84c17334affed1fb0d979dL80-R80): Updated the default value for `ProblemStatus` in the `Problem` struct from `1` to `0`.