### PR TITLE
feat(user): 重构用户修改密码功能

### DIFF
--- a/internal/service/user/select.go
+++ b/internal/service/user/select.go
@@ -27,6 +27,19 @@ func SelectById(id uint64) (entity.User, error) {
 	return u, nil
 }
 
+func SelectByEmail(email string) (entity.User, error) {
+	u, err := dao.SelectUserByEmail(email)
+	if err != nil {
+		log.Println(err)
+		return entity.User{}, errors.New("用户不存在")
+	}
+
+	// 不返回密码
+	u.Password = ""
+
+	return u, nil
+}
+
 // 查询所有用户
 func Select(condition dao.UserWhere, page uint64, size uint64) (UserPage, error) {
 	users, err := dao.SelectUsers(condition, page, size)

--- a/server/routes/user.go
+++ b/server/routes/user.go
@@ -13,6 +13,7 @@ func InitUserRoute(ginServer *gin.Engine) {
 		userPublicRoute.GET("/:id", handler.UserInfo)
 		userPublicRoute.POST("/login", handler.UserLogin)
 		userPublicRoute.POST("/register", handler.UserRegister)
+		userPublicRoute.PUT("/password", handler.UserChangePassword)
 	}
 	userProtectedRoute := ginServer.Group("/user")
 	{
@@ -21,7 +22,6 @@ func InitUserRoute(ginServer *gin.Engine) {
 
 		userProtectedRoute.GET("/current", handler.UserCurrentId)
 		userProtectedRoute.PUT("/modify/:id", handler.UserModify)
-		userProtectedRoute.PUT("/password/:id", handler.UserChangePassword)
 		userProtectedRoute.POST("/avatar/:id", handler.ModifyUserAvatar)
 	}
 }


### PR DESCRIPTION
- 将 UserChangePassword 函数的参数从 ID 改为 Email
- 增加了对普通用户通过验证码验证的逻辑
- 修改了路由，将 /password/:id 改为 /password