### PR TITLE
fix(dao): 修复更新题目时处理空值字段的问题

### DIFF
--- a/internal/dao/problem.go
+++ b/internal/dao/problem.go
@@ -126,7 +126,10 @@ func SelectProblems(condition model.ProblemWhere) ([]entity.Problem, error) {
 
 // 根据ID更新题目
 func UpdateProblemById(p entity.Problem) error {
-	tx := db.Db.Model(&p).Where("id = ?", p.Id).Updates(p)
+	// 明确指定要更新的字段，包含需要处理空值的字段
+	tx := db.Db.Model(&p).
+		Select("title", "source", "difficulty", "time_limit", "memory_limit", "description", "input", "output", "sample_input", "sample_output", "hint", "status", "update_time").
+		Updates(p)
 	if tx.Error != nil {
 		return tx.Error
 	}


### PR DESCRIPTION
- 在 UpdateProblemById 函数中，使用 Select 明确指定要更新的字段
- 这样可以确保在更新记录时正确处理空值字段，避免潜在的数据不一致问题