### PR TITLE
为实体类型生成枚举验证代码；优化参数验证和错误处理；更新用户相关接口的邮箱验证规则；

### DIFF
--- a/internal/entity/blog.go
+++ b/internal/entity/blog.go
@@ -3,6 +3,7 @@ package entity
 import "time"
 
 // BlogStatus 状态：1 屏蔽, 2 草稿, 3 公开, 4 公告
+//go:generate go run ../../utils/gen/enum_valid.go BlogStatus entity
 type BlogStatus uint8
 
 const (

--- a/internal/entity/collection.go
+++ b/internal/entity/collection.go
@@ -5,6 +5,8 @@ import (
 )
 
 // CollectionStatus 题单状态: 1 私有, 2 公开
+//
+//go:generate go run ../../utils/gen/enum_valid.go CollectionStatus entity
 type CollectionStatus uint8
 
 const (

--- a/internal/entity/comment.go
+++ b/internal/entity/comment.go
@@ -3,6 +3,7 @@ package entity
 import "time"
 
 // CommentStatus 状态：1 屏蔽, 2 公开
+//go:generate go run ../../utils/gen/enum_valid.go CommentStatus entity
 type CommentStatus uint8
 
 const (

--- a/internal/entity/history.go
+++ b/internal/entity/history.go
@@ -5,6 +5,8 @@ import (
 )
 
 // Operation 操作：0 未知，1 添加，2 修改，3 删除
+//
+//go:generate go run ../../utils/gen/enum_valid.go Operation entity
 type Operation uint8
 
 const (

--- a/internal/entity/problem.go
+++ b/internal/entity/problem.go
@@ -5,6 +5,8 @@ import (
 )
 
 // Difficulty 难度：0 未知，1 入门，2 简单，3 中等，4 较难，5 困难，6 超难
+//
+//go:generate go run ../../utils/gen/enum_valid.go Difficulty entity
 type Difficulty uint8
 
 const (

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -9,6 +9,8 @@ import (
 )
 
 // Role 角色：0 访客，1 用户，2 编辑，3 管理，4 站长
+//
+//go:generate go run ../../utils/gen/enum_valid.go Role entity
 type Role uint8
 
 const (

--- a/internal/service/blog/insert.go
+++ b/internal/service/blog/insert.go
@@ -9,13 +9,21 @@ import (
 )
 
 // 插入博客
-func Insert(b entity.Blog) (uint64, error) {
+func Insert(b entity.Blog, role entity.Role) (uint64, error) {
 	var err error
 
 	updateTime := time.Now()
 	b.UpdateTime = updateTime
 	b.CreateTime = updateTime
 
+	if role < entity.RoleAdmin {
+		if b.Status == entity.BlogBanned {
+			return 0, errors.New("无法发布封禁博客")
+		}
+		if b.Status == entity.BlogNotice {
+			return 0, errors.New("只有管理员才能发布公告")
+		}
+	}
 	// 插入博客
 	b.Id, err = dao.InsertBlog(b)
 	if err != nil {

--- a/server/handler/blog.go
+++ b/server/handler/blog.go
@@ -49,7 +49,7 @@ type ReqBlogSave struct {
 	ProblemId uint64            `json:"problem_id,omitempty"`
 	Title     string            `json:"title" binding:"required"`
 	Content   string            `json:"content" binding:"required"`
-	Status    entity.BlogStatus `json:"status,omitempty"`
+	Status    entity.BlogStatus `json:"status,omitempty" binding:"required,statusRange"`
 }
 
 func BlogUpload(c *gin.Context) {
@@ -60,7 +60,7 @@ func BlogUpload(c *gin.Context) {
 	err := c.ShouldBindBodyWithJSON(&req)
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusBadRequest, model.RespError("参数错误", nil))
+		c.JSON(http.StatusBadRequest, model.RespError("参数错误", err.Error()))
 		return
 	}
 
@@ -89,7 +89,7 @@ type ReqBlogEdit struct {
 	ProblemId uint64            `json:"problem_id,omitempty"`
 	Title     string            `json:"title,omitempty" binding:"required"`
 	Content   string            `json:"content,omitempty" binding:"required"`
-	Status    entity.BlogStatus `json:"status,omitempty" binding:"required"`
+	Status    entity.BlogStatus `json:"status,omitempty" binding:"required,statusRange"`
 }
 
 func BlogEdit(c *gin.Context) {
@@ -100,7 +100,7 @@ func BlogEdit(c *gin.Context) {
 	err := c.ShouldBindBodyWithJSON(&req)
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusBadRequest, model.RespError("参数错误", nil))
+		c.JSON(http.StatusBadRequest, model.RespError("参数错误", err.Error()))
 		return
 	}
 
@@ -143,43 +143,4 @@ func BlogRemove(c *gin.Context) {
 
 	// 返回结果
 	c.JSON(http.StatusOK, model.RespOk("删除成功", nil))
-}
-
-// 添加博客
-type ReqBlogAdd struct {
-	UserId    uint64            `json:"user_id,omitempty" binding:"required"`
-	ProblemId uint64            `json:"problem_id,omitempty" binding:"required"`
-	Title     string            `json:"title,omitempty" binding:"required"`
-	Content   string            `json:"content,omitempty" binding:"required"`
-	Status    entity.BlogStatus `json:"status,omitempty"`
-}
-
-func BlogAdd(c *gin.Context) {
-	var req ReqBlogAdd
-
-	// 参数绑定
-	err := c.ShouldBindBodyWithJSON(&req)
-	if err != nil {
-		log.Println(err)
-		c.JSON(http.StatusBadRequest, model.RespOk("参数错误", nil))
-		return
-	}
-
-	b := entity.Blog{
-		UserId:    req.UserId,
-		ProblemId: req.ProblemId,
-		Title:     req.Title,
-		Content:   req.Content,
-		Status:    req.Status,
-	}
-
-	// 插入博客
-	b.Id, err = blog.Insert(b)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, model.RespOk(err.Error(), nil))
-		return
-	}
-
-	// 返回结果
-	c.JSON(http.StatusOK, model.RespOk("添加成功，返回博客ID", b.Id))
 }

--- a/server/handler/collection.go
+++ b/server/handler/collection.go
@@ -52,7 +52,7 @@ func CollectionList(c *gin.Context) {
 type ReqCollectionAdd struct {
 	Title       string                  `json:"title" binding:"required"`
 	Description string                  `json:"description" binding:"required"`
-	Status      entity.CollectionStatus `json:"status" binding:"required"`
+	Status      entity.CollectionStatus `json:"status" binding:"required,statusRange"`
 }
 
 func CollectionAdd(c *gin.Context) {
@@ -64,7 +64,7 @@ func CollectionAdd(c *gin.Context) {
 	err := c.ShouldBindBodyWithJSON(&req)
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusBadRequest, model.RespError("参数错误", nil))
+		c.JSON(http.StatusBadRequest, model.RespError("参数错误", err.Error()))
 		return
 	}
 
@@ -92,7 +92,7 @@ type ReqCollectionModify struct {
 	Id          uint64                  `json:"id" binding:"required"`
 	Title       string                  `json:"title" binding:"required"`
 	Description string                  `json:"description" binding:"required"`
-	Status      entity.CollectionStatus `json:"status" binding:"required"`
+	Status      entity.CollectionStatus `json:"status" binding:"required,statusRange"`
 }
 
 func CollectionModify(c *gin.Context) {
@@ -104,7 +104,7 @@ func CollectionModify(c *gin.Context) {
 	err := c.ShouldBindBodyWithJSON(&req)
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusBadRequest, model.RespError("参数错误", nil))
+		c.JSON(http.StatusBadRequest, model.RespError("参数错误", err.Error()))
 		return
 	}
 

--- a/server/handler/comment.go
+++ b/server/handler/comment.go
@@ -90,7 +90,7 @@ type ReqCommentModify struct {
 	UserId  uint64               `json:"user_id,omitempty" binding:"required"`
 	BlogId  uint64               `json:"blog_id,omitempty" binding:"required"`
 	Content string               `json:"content,omitempty" binding:"required"`
-	Status  entity.CommentStatus `json:"status,omitempty"`
+	Status  entity.CommentStatus `json:"status,omitempty" binding:"required,statusRange"`
 }
 
 func CommentModify(c *gin.Context) {
@@ -100,7 +100,7 @@ func CommentModify(c *gin.Context) {
 	err := c.ShouldBindBodyWithJSON(&req)
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusBadRequest, model.RespOk("参数错误", nil))
+		c.JSON(http.StatusBadRequest, model.RespOk("参数错误", err.Error()))
 		return
 	}
 

--- a/server/handler/language.go
+++ b/server/handler/language.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 )
 
 // 获取语言列表
@@ -36,7 +35,7 @@ type ReqLanguageUpdate struct {
 func UpdateLanguage(c *gin.Context) {
 	role, _ := utils.GetUserInfo(c)
 	var req ReqLanguageUpdate
-	if err := c.ShouldBindBodyWith(&req, binding.JSON); err != nil {
+	if err := c.ShouldBindBodyWithJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, model.RespError("参数错误", err.Error()))
 		return
 	}

--- a/server/handler/problem.go
+++ b/server/handler/problem.go
@@ -77,7 +77,7 @@ func ProblemAdd(c *gin.Context) {
 	err := c.ShouldBindBodyWithJSON(&req)
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusBadRequest, model.RespError("参数错误", nil))
+		c.JSON(http.StatusBadRequest, model.RespError("参数错误", err.Error()))
 		return
 	}
 
@@ -111,7 +111,7 @@ type ReqProblemModify struct {
 	Id           uint64               `json:"id" binding:"required"`
 	Title        string               `json:"title" binding:"required"`
 	Source       string               `json:"source"`
-	Difficulty   entity.Difficulty    `json:"difficulty" binding:"required"`
+	Difficulty   entity.Difficulty    `json:"difficulty" binding:"required,statusRange"`
 	TimeLimit    float64              `json:"time_limit" binding:"required"`
 	MemoryLimit  uint64               `json:"memory_limit" binding:"required"`
 	Description  string               `json:"description" binding:"required"`
@@ -120,7 +120,7 @@ type ReqProblemModify struct {
 	SampleInput  string               `json:"sample_input" binding:"required"`
 	SampleOutput string               `json:"sample_output" binding:"required"`
 	Hint         string               `json:"hint"`
-	Status       entity.ProblemStatus `json:"status" binding:"required"`
+	Status       entity.ProblemStatus `json:"status" binding:"required,statusRange"`
 }
 
 // 修改题目
@@ -132,7 +132,7 @@ func ProblemModify(c *gin.Context) {
 	err := c.ShouldBindBodyWithJSON(&req)
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusBadRequest, model.RespError("参数错误", nil))
+		c.JSON(http.StatusBadRequest, model.RespError("参数错误", err.Error()))
 		return
 	}
 

--- a/server/handler/user.go
+++ b/server/handler/user.go
@@ -19,7 +19,7 @@ import (
 type ReqUserRegister struct {
 	Username   string       `json:"username" binding:"required,min=3,max=16"`
 	Password   string       `json:"password" binding:"required,min=6,max=16"`
-	Email      entity.Email `json:"email" binding:"required,max=50"`
+	Email      entity.Email `json:"email" binding:"required,email"`
 	VerifyCode string       `json:"verify_code" binding:"required,max=10"`
 }
 
@@ -64,7 +64,7 @@ func UserRegister(c *gin.Context) {
 // 用户登录
 type ReqUserLogin struct {
 	Password string       `json:"password" binding:"required,min=6,max=16"`
-	Email    entity.Email `json:"email" binding:"required,max=50"`
+	Email    entity.Email `json:"email" binding:"required,email"`
 }
 
 func UserLogin(c *gin.Context) {
@@ -126,7 +126,7 @@ func UserCurrentId(c *gin.Context) {
 // 修改用户信息
 type ReqUserModify struct {
 	Username  string       `json:"username" binding:"required,min=3,max=16"`
-	Email     entity.Email `json:"email" binding:"required,max=50"`
+	Email     entity.Email `json:"email" binding:"required,email"`
 	Signature string       `json:"signature" binding:"required,max=50"`
 }
 
@@ -174,7 +174,7 @@ func UserModify(c *gin.Context) {
 
 // 修改用户密码
 type ReqUserChangePassword struct {
-	Email      entity.Email `json:"email" binding:"required,min=3,max=16"`
+	Email      entity.Email `json:"email" binding:"required,email"`
 	Password   string       `json:"password" binding:"required,min=6,max=16"`
 	VerifyCode string       `json:"verify_code" binding:"required,max=10"`
 }
@@ -273,7 +273,7 @@ func UserList(c *gin.Context) {
 type ReqUserAdd struct {
 	Username  string       `json:"username" binding:"required,min=3,max=16"`
 	Password  string       `json:"password" binding:"required,min=6,max=20"`
-	Email     entity.Email `json:"email" binding:"required,max=50"`
+	Email     entity.Email `json:"email" binding:"required,email"`
 	Avatar    string       `json:"avatar" binding:"required"`
 	Signature string       `json:"signature" binding:"required,max=50"`
 }

--- a/server/handler/user.go
+++ b/server/handler/user.go
@@ -329,7 +329,7 @@ func UserRemove(c *gin.Context) {
 // 设置用户角色
 type ReqUserModifyRole struct {
 	Id   uint64      `json:"id" binding:"required"`
-	Role entity.Role `json:"role" binding:"required"`
+	Role entity.Role `json:"role" binding:"required,statusRange"`
 }
 
 func UserModifyRole(c *gin.Context) {
@@ -340,7 +340,7 @@ func UserModifyRole(c *gin.Context) {
 	err := c.ShouldBindBodyWithJSON(&req)
 	if err != nil {
 		log.Println(err)
-		c.JSON(http.StatusBadRequest, model.RespError("参数错误", nil))
+		c.JSON(http.StatusBadRequest, model.RespError("参数错误", err.Error()))
 		return
 	}
 


### PR DESCRIPTION
- 在 blog、collection、comment、history、problem 和 user 实体中添加了枚举验证代码生成注释
- 使用 go:generate 指令调用枚举验证代码生成工具
- 生成的代码将用于验证枚举类型的合法性，提高数据一致性和安全性
- 在博客、收藏、评论、语言、问题和用户处理中统一了参数验证逻辑
- 引入了自定义验证器 "statusRange" 以检查状态值是否有效
- 优化了错误响应，返回具体的验证错误信息
- 移除了冗余的 BlogAdd 接口
- 在用户注册、登录、修改信息、重置密码和添加用户接口中，将邮箱验证规则从"required,max=50"修改为"required,email"
- 这个修改确保了邮箱格式的正确性，提高了数据