### PR TITLE
feat(yuki): 增加yuki-image初始化功能

### DIFF
--- a/internal/infrastructure/yuki/album.go
+++ b/internal/infrastructure/yuki/album.go
@@ -14,12 +14,7 @@ func GetAlbumList() ([]YukiAlbum, error) {
 		return nil, err
 	}
 
-	type tmpResponses struct {
-		Code    int                      `json:"code"`
-		Message string                   `json:"message"`
-		Data    []map[string]interface{} `json:"data"`
-	}
-	var responses tmpResponses
+	var responses YukiResponses
 
 	err = json.Unmarshal([]byte(bodystr), &responses)
 	if err != nil {
@@ -31,13 +26,13 @@ func GetAlbumList() ([]YukiAlbum, error) {
 	var albumList []YukiAlbum
 	err = mapstructure.Decode(responses.Data, &albumList)
 	if err != nil {
-		return nil, err
+		return nil, nil
 	}
 	return albumList, nil
 }
 
 func GetAlbum(albumId uint64) (YukiAlbum, error) {
-	bodystr, err := httpInteraction("/album/"+string(albumId), "GET", nil)
+	bodystr, err := httpInteraction("/album/"+GetAlbumName(uint8(albumId)), "GET", nil)
 	if err != nil {
 		return YukiAlbum{}, err
 	}
@@ -59,9 +54,9 @@ func GetAlbum(albumId uint64) (YukiAlbum, error) {
 
 func CreateAlbum(name string, height, width int64) (YukiAlbum, error) {
 	data := map[string]interface{}{
-		"name":   name,
-		"height": height,
-		"width":  width,
+		"name":       name,
+		"max_height": height,
+		"max_width":  width,
 	}
 	jsonData, err := json.Marshal(data)
 	if err != nil {

--- a/internal/infrastructure/yuki/album.go
+++ b/internal/infrastructure/yuki/album.go
@@ -105,3 +105,25 @@ func AlbumAddFormat(album uint8, format uint64) error {
 	}
 	return nil
 }
+
+func AlbumGetFormat(album uint8) ([]YukiFormat, error) {
+	albumName := GetAlbumName(album)
+	bodystr, err := httpInteraction("/album/format/"+albumName, "GET", nil)
+	if err != nil {
+		return nil, err
+	}
+	var responses YukiResponses
+	err = json.Unmarshal([]byte(bodystr), &responses)
+	if err != nil {
+		return nil, err
+	}
+	if responses.Code == 0 {
+		return nil, errors.New(responses.Message)
+	}
+	var formatList []YukiFormat
+	err = mapstructure.Decode(responses.Data, &formatList)
+	if err != nil {
+		return nil, err
+	}
+	return formatList, nil
+}

--- a/internal/infrastructure/yuki/album.go
+++ b/internal/infrastructure/yuki/album.go
@@ -1,6 +1,7 @@
 package yuki
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 
@@ -54,4 +55,58 @@ func GetAlbum(albumId uint64) (YukiAlbum, error) {
 		return YukiAlbum{}, err
 	}
 	return album, nil
+}
+
+func CreateAlbum(name string, height, width int64) (YukiAlbum, error) {
+	data := map[string]interface{}{
+		"name":   name,
+		"height": height,
+		"width":  width,
+	}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return YukiAlbum{}, err
+	}
+	bodystr, err := httpInteraction("/album", "POST", bytes.NewReader(jsonData))
+	if err != nil {
+		return YukiAlbum{}, err
+	}
+	var responses YukiResponses
+	err = json.Unmarshal([]byte(bodystr), &responses)
+	if err != nil {
+		return YukiAlbum{}, err
+	}
+	if responses.Code == 0 {
+		return YukiAlbum{}, errors.New(responses.Message)
+	}
+	var album YukiAlbum
+	err = mapstructure.Decode(responses.Data, &album)
+	if err != nil {
+		return YukiAlbum{}, err
+	}
+	return album, nil
+}
+
+func AlbumAddFormat(album uint8, format uint64) error {
+	data := map[string]interface{}{
+		"format_name": GetFormatName(format),
+		"album_name":  GetAlbumName(album),
+	}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	bodystr, err := httpInteraction("/album/format", "POST", bytes.NewReader(jsonData))
+	if err != nil {
+		return err
+	}
+	var responses YukiResponses
+	err = json.Unmarshal([]byte(bodystr), &responses)
+	if err != nil {
+		return err
+	}
+	if responses.Code == 0 {
+		return errors.New(responses.Message)
+	}
+	return nil
 }

--- a/internal/infrastructure/yuki/model.go
+++ b/internal/infrastructure/yuki/model.go
@@ -73,6 +73,21 @@ func GetFormatName(id uint64) string {
 	}
 }
 
+// GetAlbumRoleByName 根据相册名称查找其对应的 uint8 角色常量。
+func GetAlbumRoleByName(name string) uint8 {
+	switch name {
+	case "avatar":
+		return YukiAvatarAlbum
+	case "problem":
+		return YukiProblemAlbum
+	case "blog":
+		return YukiBlogAlbum
+	default:
+		return 0 // 或者一个表示未知的常量
+	}
+}
+
+// GetAlbumName 根据角色获取相册名称。
 func GetAlbumName(role uint8) string {
 	switch role {
 	case YukiAvatarAlbum:

--- a/internal/infrastructure/yuki/model.go
+++ b/internal/infrastructure/yuki/model.go
@@ -102,9 +102,9 @@ func GetAlbumName(role uint8) string {
 }
 
 type YukiResponses struct {
-	Code    int                    `json:"code"`
-	Message string                 `json:"message"`
-	Data    map[string]interface{} `json:"data"`
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
 }
 
 type YukiAlbum struct {

--- a/internal/infrastructure/yuki/model.go
+++ b/internal/infrastructure/yuki/model.go
@@ -12,6 +12,67 @@ const (
 	YukiBlogAlbum    uint8 = 3
 )
 
+var wantAlbum = []YukiAlbum{
+	{
+		Name:      GetAlbumName(YukiAvatarAlbum),
+		MaxHeight: 512,
+		MaxWidth:  512,
+		FormatSupport: []YukiFormat{
+			{
+				Id: JPEG,
+			},
+			{
+				Id: PNG,
+			},
+		},
+	},
+	{
+		Name:      GetAlbumName(YukiProblemAlbum),
+		MaxHeight: 1080,
+		MaxWidth:  1920,
+		FormatSupport: []YukiFormat{
+			{
+				Id: JPEG,
+			},
+			{
+				Id: PNG,
+			},
+			{
+				Id: GIF,
+			},
+		},
+	},
+	{
+		Name:      GetAlbumName(YukiBlogAlbum),
+		MaxHeight: 1080,
+		MaxWidth:  1920,
+		FormatSupport: []YukiFormat{
+			{
+				Id: JPEG,
+			},
+			{
+				Id: PNG,
+			},
+			{
+				Id: GIF,
+			},
+		},
+	},
+}
+
+func GetFormatName(id uint64) string {
+	switch id {
+	case JPEG:
+		return "jpeg"
+	case PNG:
+		return "png"
+	case GIF:
+		return "gif"
+	default:
+		return "unknown"
+	}
+}
+
 func GetAlbumName(role uint8) string {
 	switch role {
 	case YukiAvatarAlbum:

--- a/internal/infrastructure/yuki/yuki.go
+++ b/internal/infrastructure/yuki/yuki.go
@@ -52,6 +52,13 @@ func InitYukiImage(host, port, token string) error {
 		}
 		currentAlbum = fullCurrentAlbum
 
+		// 检查并补充 FormatSupport
+		currentAlbum.FormatSupport, err = AlbumGetFormat(GetAlbumRoleByName(wantedAlbum.Name))
+		if err != nil {
+			log.Printf("Error fetching formats for album '%s' (ID: %d): %v", currentAlbum.Name, currentAlbum.Id, err)
+			return err
+		}
+
 		existingFormats := make(map[uint64]bool)
 		for _, format := range currentAlbum.FormatSupport {
 			existingFormats[format.Id] = true

--- a/internal/infrastructure/yuki/yuki.go
+++ b/internal/infrastructure/yuki/yuki.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 )
 
+// InitYukiImage 初始化 Yuki Image 服务客户端，并确保预期的相册和格式存在。
+// 它会连接到 Yuki Image 服务，获取现有相册列表，
+// 然后遍历 `wantAlbum` 中定义的期望相册配置。
+// 如果相册不存在，则创建它；接着，检查并补充该相册所缺少的 `FormatSupport`。
 func InitYukiImage(host, port, token string) error {
 	config = YukiConf{
 		Host:  host,
@@ -15,10 +19,67 @@ func InitYukiImage(host, port, token string) error {
 	}
 	preUrl = config.Host + ":" + config.Port + "/api/v1"
 	log.Println("Connecting to yuki-image service: " + preUrl)
-	_, err := GetAlbumList()
+	albums, err := GetAlbumList()
 	if err != nil {
 		return err
 	}
+	albumsMap := make(map[string]YukiAlbum)
+	for _, album := range albums {
+		albumsMap[album.Name] = album
+	}
+
+	for _, wantedAlbum := range wantAlbum {
+		currentAlbum, albumExists := albumsMap[wantedAlbum.Name]
+		if !albumExists {
+			log.Printf("Album '%s' not found, creating...", wantedAlbum.Name)
+			createdAlbum, err := CreateAlbum(wantedAlbum.Name, int64(wantedAlbum.MaxHeight), int64(wantedAlbum.MaxWidth))
+			if err != nil {
+				log.Printf("Error creating album '%s': %v", wantedAlbum.Name, err)
+				return err
+			}
+			albumsMap[createdAlbum.Name] = createdAlbum
+			currentAlbum = createdAlbum
+			log.Printf("Album '%s' created successfully with ID: %d", currentAlbum.Name, currentAlbum.Id)
+		} else {
+			log.Printf("Album '%s' already exists with ID: %d", currentAlbum.Name, currentAlbum.Id)
+		}
+
+		// 确保获取最新的相册信息，特别是 FormatSupport
+		fullCurrentAlbum, err := GetAlbum(currentAlbum.Id)
+		if err != nil {
+			log.Printf("Error fetching full details for album '%s' (ID: %d): %v", currentAlbum.Name, currentAlbum.Id, err)
+			return err
+		}
+		currentAlbum = fullCurrentAlbum
+
+		existingFormats := make(map[uint64]bool)
+		for _, format := range currentAlbum.FormatSupport {
+			existingFormats[format.Id] = true
+		}
+
+		albumRole := GetAlbumRoleByName(currentAlbum.Name)
+		if albumRole == 0 {
+			log.Printf("Unknown album role for name: %s", currentAlbum.Name)
+			// 根据需要处理未知角色，例如跳过或返回错误
+			continue
+		}
+
+		for _, wantedFormat := range wantedAlbum.FormatSupport {
+			if !existingFormats[wantedFormat.Id] {
+				log.Printf("Format '%s' not found in album '%s', adding...", GetFormatName(wantedFormat.Id), currentAlbum.Name)
+				err := AlbumAddFormat(albumRole, wantedFormat.Id)
+				if err != nil {
+					log.Printf("Error adding format '%s' to album '%s': %v", GetFormatName(wantedFormat.Id), currentAlbum.Name, err)
+					return err
+				}
+				log.Printf("Format '%s' added successfully to album '%s'", GetFormatName(wantedFormat.Id), currentAlbum.Name)
+			} else {
+				log.Printf("Format '%s' already exists in album '%s'", GetFormatName(wantedFormat.Id), currentAlbum.Name)
+			}
+		}
+	}
+
+	log.Println("Yuki-image service initialization and album/format check completed.")
 	return nil
 }
 


### PR DESCRIPTION
在程序启动阶段，会检查所需相册与其格式支持是否完整，若不完整则进行创建与补充。

- 在`model.go`中新增`wantAlbum`变量，定义不同相册的格式支持及最大尺寸。同时添加`GetFormatName`函数，用于根据格式ID获取格式名称。这些改动为后续处理相册数据提供了必要的支持。
- 新增了 `CreateAlbum` 和 `AlbumAddFormat` 函数，用于创建专辑和向专辑中添加格式。这些功能通过 HTTP 请求与后端交互，并处理 JSON 数据的编码和解码。
- 添加 GetAlbumRoleByName 函数以根据相册名称获取角色常量。完善 InitYukiImage 函数，确保初始化时检查并创建缺失的相册和格式，提升服务的健壮性。
- 在`model.go`中新增`wantAlbum`变量，定义不同相册的格式支持及最大尺寸。同时添加`GetFormatName`函数，用于根据格式ID获取格式名称。这些改动为后续处理相册数据提供了必要的支持。
- 新增了 `CreateAlbum` 和 `AlbumAddFormat` 函数，用于创建专辑和向专辑中添加格式。这些功能通过 HTTP 请求与后端交互，并处理 JSON 数据的编码和解码。
- 添加 GetAlbumRoleByName 函数以根据相册名称获取角色常量。完善 InitYukiImage 函数，确保初始化时检查并创建缺失的相册和格式，提升服务的健壮性。
- 将 `YukiResponses` 中的 `Data` 字段从 `map[string]interface{}` 改为 `interface{}`，提高代码通用性
- 移除 `GetAlbumList` 中的临时结构体 `tmpResponses`，直接使用 `YukiResponses`
- 在 `GetAlbum` 中调用 `GetAlbumName` 生成 URL 路径，提高代码复用性
- 修改 `CreateAlbum` 中的字段名，使其更符合语义